### PR TITLE
Add main PR source policy

### DIFF
--- a/.github/workflows/main-pr-source-policy.yml
+++ b/.github/workflows/main-pr-source-policy.yml
@@ -1,0 +1,19 @@
+name: main-pr-source-policy
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  require-ui-source:
+    name: main-pr-source-policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require ui as the source branch for main
+        run: |
+          if [ "${{ github.head_ref }}" != "ui" ]; then
+            echo "Pull requests targeting main must come from the ui branch."
+            echo "Current source branch: ${{ github.head_ref }}"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a GitHub Actions check that only allows pull requests targeting main when the source branch is ui. This supports the repository workflow: collaborators merge into ui first, then admins merge ui into main.